### PR TITLE
Fix proxy being cleared after getting a new access token

### DIFF
--- a/PSSailpoint/Configuration.ps1
+++ b/PSSailpoint/Configuration.ps1
@@ -265,7 +265,7 @@ function Get-AccessToken {
                     $Data = ConvertFrom-Json $Response.Content
                     $Token = $Data.access_token
                     $TokenExpiration = (Get-Date).AddSeconds($Data.expires_in)
-                    Set-DefaultConfiguration -Token $Token -TokenExpiration $TokenExpiration
+                    Set-DefaultConfiguration -Token $Token -TokenExpiration $TokenExpiration -Proxy $Script:$Configuration["Proxy"]
                     return $Token
                 } 
 


### PR DESCRIPTION
Fix proxy being cleared after getting a new access token